### PR TITLE
FIx behaviour when builds fail

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -224,7 +224,8 @@ Stage: final
 				"  - r-seurat@4 arch=None-None-x86_64_v4\n  - py-anndata@3.14 arch=None-None-x86_64_v4\n  view")
 
 			mwr.SetRunning()
-			<-mwr.Ch
+			_, err = mwr.Wait("")
+			So(err, ShouldBeNil)
 			hash := fmt.Sprintf("%X", sha256.Sum256([]byte(ms3.Data)))
 			So(mwr.Cmd, ShouldContainSubstring, "echo doing build with hash "+hash+"; sudo singularity build")
 
@@ -347,8 +348,9 @@ packages:
 			err := builder.Build(def)
 			So(err, ShouldBeNil)
 
-			mwr.SetRunning()
-			<-mwr.Ch
+			mwr.SetComplete()
+			_, err = mwr.Wait("")
+			So(err, ShouldBeNil)
 
 			ok := waitFor(func() bool {
 				return logWriter.String() != ""
@@ -356,7 +358,7 @@ packages:
 			So(ok, ShouldBeTrue)
 
 			So(logWriter.String(), ShouldContainSubstring,
-				"msg=\"Async part of build failed\" err=\"Mock error\" s3Path=some_path/"+def.getS3Path())
+				"msg=\"Async part of build failed\" err=\""+ErrBuildFailed+"\" s3Path=some_path/"+def.getS3Path())
 
 			data, ok := mc.GetFile(filepath.Join(def.getRepoPath(), core.BuilderOut))
 			So(ok, ShouldBeTrue)
@@ -395,8 +397,10 @@ packages:
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, ErrEnvironmentBuilding)
 
-			mr.Wait(jobID1)
-			mr.Wait(jobID2)
+			_, err = mr.Wait(jobID1)
+			So(err, ShouldBeNil)
+			_, err = mr.Wait(jobID2)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("When the Core doesn't respond we get a meaningful error", func() {
@@ -425,7 +429,6 @@ packages:
 			mc.Err = internal.Error("an error")
 
 			logWriter.Reset()
-			mwr.Ch = make(chan struct{})
 			conf.Module.ModuleInstallDir = t.TempDir()
 			conf.Module.ScriptsInstallDir = t.TempDir()
 

--- a/internal/tests.go
+++ b/internal/tests.go
@@ -131,7 +131,6 @@ func (m *MockS3) OpenFile(source string) (io.ReadCloser, error) {
 
 // MockWR can be used to test a build.Builder without having real wr running.
 type MockWR struct {
-	Ch                    chan struct{}
 	Cmd                   string
 	Fail                  bool
 	PollForStatusInterval time.Duration
@@ -143,7 +142,6 @@ type MockWR struct {
 
 func NewMockWR(pollForStatusInterval, jobDuration time.Duration) *MockWR {
 	return &MockWR{
-		Ch:                    make(chan struct{}),
 		PollForStatusInterval: pollForStatusInterval,
 		JobDuration:           jobDuration,
 	}
@@ -189,11 +187,10 @@ func (m *MockWR) WaitForRunning(string) error { //nolint:unparam
 
 // Wait implements build.Runner interface.
 func (m *MockWR) Wait(string) (wr.WRJobStatus, error) {
-	defer close(m.Ch)
 	<-time.After(m.JobDuration)
 
 	if m.Fail {
-		return wr.WRJobStatusBuried, ErrMock
+		return wr.WRJobStatusBuried, nil
 	}
 
 	return wr.WRJobStatusComplete, nil

--- a/internal/tests.go
+++ b/internal/tests.go
@@ -165,6 +165,13 @@ func (m *MockWR) SetRunning() {
 	m.ReturnStatus = wr.WRJobStatusRunning
 }
 
+func (m *MockWR) SetComplete() {
+	m.Lock()
+	defer m.Unlock()
+
+	m.ReturnStatus = wr.WRJobStatusComplete
+}
+
 // WaitForRunning implements build.Runner interface.
 func (m *MockWR) WaitForRunning(string) error { //nolint:unparam
 	for {

--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,7 @@ func New(b Builder) http.Handler {
 		case endpointEnvsStatus:
 			handleEnvStatus(b, w)
 		default:
-			http.Error(w, "Not found", http.StatusNotFound)
+			http.Error(w, fmt.Sprintf("go-softpack-builder: no such endpoint: %s", r.URL.Path), http.StatusNotFound)
 		}
 	})
 }

--- a/wr/wr.go
+++ b/wr/wr.go
@@ -126,6 +126,8 @@ func (r *Runner) runWRCmd(cmd *exec.Cmd) (string, error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	slog.Debug("ran wr command", "cmd", cmd.String(), "stdout", stdout.String(), "stderr", stderr.String(), "err", err, "exitcode", cmd.ProcessState.ExitCode())
+
 	if err != nil {
 		errStr := stderr.String()
 		if !strings.Contains(errStr, "EROR") {

--- a/wr/wr.go
+++ b/wr/wr.go
@@ -126,7 +126,8 @@ func (r *Runner) runWRCmd(cmd *exec.Cmd) (string, error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-	slog.Debug("ran wr command", "cmd", cmd.String(), "stdout", stdout.String(), "stderr", stderr.String(), "err", err, "exitcode", cmd.ProcessState.ExitCode())
+	slog.Debug("ran wr command", "cmd", cmd.String(), "stdout", stdout.String(),
+		"stderr", stderr.String(), "err", err, "exitcode", cmd.ProcessState.ExitCode())
 
 	if err != nil {
 		errStr := stderr.String()


### PR DESCRIPTION
We broke detection of wr jobs failing, so it would think the build succeeded and then try to grab the built artifacts out of S3 and fail. (This fixes that.)