### PR TITLE
Use Xvfb during installs to allow (R) packages, that require an X connection, to install.

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -141,7 +141,11 @@ EOF
 	spack buildcache keys --install --trust
 	spack config add "config:install_tree:padded_length:128"
 	spack -e . concretize
-	spack -e . install --fail-fast || {
+	if bash -c "type -P xvfb-run" > /dev/null; then
+		xvfb-run -a spack -e . install --fail-fast
+	else
+		spack -e . install --fail-fast
+	fi || {
 		spack -e . buildcache push -a s3cache
 		false
 	}

--- a/build/singularity.tmpl
+++ b/build/singularity.tmpl
@@ -31,7 +31,11 @@ EOF
 	spack buildcache keys --install --trust
 	spack config add "config:install_tree:padded_length:128"
 	spack -e . concretize
-	spack -e . install --fail-fast || {
+	if bash -c "type -P xvfb-run" > /dev/null; then
+		xvfb-run -a spack -e . install --fail-fast
+	else
+		spack -e . install --fail-fast
+	fi || {
 		spack -e . buildcache push -a s3cache
 		false
 	}


### PR DESCRIPTION
`singularity.def` updated to conditionally use xvfb-run to give `spack install` access to a psuedo X-server so that packages that require one during installation will install without issue.