### PR TITLE
Don't use build cache during dependency resolution.

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -146,14 +146,14 @@ EOF
 
 	# Install all the required software
 	. /opt/spack/share/spack/setup-env.sh
-	spack mirror add s3cache "s3://spack"
 	tmpDir="$(mktemp -d)"
 	git clone "`+gmhttp.URL+`" "$tmpDir"
 	git -C "$tmpDir" checkout "`+commitHash+`"
 	spack repo add "$tmpDir"
-	spack buildcache keys --install --trust
 	spack config add "config:install_tree:padded_length:128"
 	spack -e . concretize
+	spack mirror add s3cache "s3://spack"
+	spack buildcache keys --install --trust
 	if bash -c "type -P xvfb-run" > /dev/null; then
 		xvfb-run -a spack -e . install --fail-fast
 	else

--- a/build/singularity.tmpl
+++ b/build/singularity.tmpl
@@ -23,14 +23,14 @@ EOF
 
 	# Install all the required software
 	. /opt/spack/share/spack/setup-env.sh
-	spack mirror add s3cache "{{ .S3BinaryCache }}"
 	tmpDir="$(mktemp -d)"
 	git clone "{{ .RepoURL }}" "$tmpDir"
 	git -C "$tmpDir" checkout "{{ .RepoRef }}"
 	spack repo add "$tmpDir"
-	spack buildcache keys --install --trust
 	spack config add "config:install_tree:padded_length:128"
 	spack -e . concretize
+	spack mirror add s3cache "{{ .S3BinaryCache }}"
+	spack buildcache keys --install --trust
 	if bash -c "type -P xvfb-run" > /dev/null; then
 		xvfb-run -a spack -e . install --fail-fast
 	else


### PR DESCRIPTION
Add build cache after concretisation, as it changes how the dependencies are determines, meaning that some recipe updates are not taken into account (e.g. deprecation).