### PR TITLE
Removing an environment should only remove the files for the specified version

### DIFF
--- a/remove/remove.go
+++ b/remove/remove.go
@@ -82,7 +82,7 @@ func Remove(conf *config.Config, s3r s3Remover, envPath, version string) error {
 		return err
 	}
 
-	if err := removeLocalFiles(modulePath, scriptPath); err != nil {
+	if err := removeLocalFiles(modulePath, version, scriptPath); err != nil {
 		return err
 	}
 
@@ -105,12 +105,22 @@ func checkWriteAccess(modulePath, scriptPath string) error {
 	return nil
 }
 
-func removeLocalFiles(modulePath, scriptPath string) error {
-	if err := removeAllNoDescend(modulePath); err != nil {
+func removeLocalFiles(modulePath, version, scriptPath string) error {
+	if err := removeAndParentIfEmpty(modulePath, version); err != nil {
 		return err
 	}
 
 	return removeAllNoDescend(scriptPath)
+}
+
+func removeAndParentIfEmpty(modulePath, version string) error {
+	if err := os.Remove(filepath.Join(modulePath, version)); err != nil {
+		return err
+	}
+
+	os.Remove(modulePath)
+
+	return nil
 }
 
 func removeAllNoDescend(path string) error {

--- a/remove/remove.go
+++ b/remove/remove.go
@@ -118,7 +118,7 @@ func removeAndParentIfEmpty(modulePath, version string) error {
 		return err
 	}
 
-	os.Remove(modulePath)
+	os.Remove(modulePath) // error deliberately ignored.
 
 	return nil
 }


### PR DESCRIPTION
Previously, using `gsb remove` would remove all of the module files for an environment, not just for the version specified.